### PR TITLE
feat(vscode): auto-open preview, dedicated editor group for webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ For manual installation, see the [Manual Installation Guide](INSTALL.md).
 | `Obsidian Preview: Update Obsidian Plugin` | Check for and install plugin updates |
 | `Obsidian Preview: Update Vault Path` | Change the detected vault path |
 
+### Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `obsidianPreview.autoOpenPreview` | `true` | Open the Obsidian preview when you focus a Markdown editor (including after a window reload with a note already open). |
+| `obsidianPreview.previewInSecondEditorGroup` | `true` | Keep the note in the **first** editor group and the preview in the **second**, so new files from the explorer open next to the source instead of stacking with the webview. Set to `false` for the previous “open beside active editor” behavior. |
+
+To further discourage new tabs from opening in the preview’s group, you can enable the editor auto-lock for this webview in your user `settings.json`:
+
+```json
+"workbench.editor.autoLockGroups": {
+  "obsidianPreview": true
+}
+```
+
+(Merge with any other `autoLockGroups` keys you already use.)
+
 ---
 
 ## Support

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -109,6 +109,16 @@
           "type": "string",
           "default": "",
           "description": "Path to your Obsidian vault (auto-detected if left empty)"
+        },
+        "obsidianPreview.autoOpenPreview": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, opening or focusing a Markdown editor automatically opens the Obsidian preview (if not already open)."
+        },
+        "obsidianPreview.previewInSecondEditorGroup": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, keep Markdown in the first editor group and open the preview in the second group so new files from the explorer usually land beside the source, not the webview. Set false to use the previous “open beside active editor” behavior."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -229,7 +229,9 @@ export function activate(context: vscode.ExtensionContext): void {
       previewPanel.dispose();
     }
     navigationStack.length = 0; // Reset history for new panel
-    previewPanel = PreviewPanel.create(ctx.extensionUri, debugMode);
+    const previewInSecondGroup =
+      vscode.workspace.getConfiguration("obsidianPreview").get<boolean>("previewInSecondEditorGroup") !== false;
+    previewPanel = await PreviewPanel.create(ctx.extensionUri, debugMode, { previewInSecondGroup });
     
     // Handle panel dispose
     previewPanel.onDispose(() => {
@@ -333,6 +335,13 @@ export function activate(context: vscode.ExtensionContext): void {
     logger.info(`Initial render: doc=${docToRender?.uri.fsPath ?? 'none'}, connected=${client.isConnected()}`);
     if (docToRender) {
       await updatePreview(docToRender);
+      if (previewInSecondGroup) {
+        try {
+          await vscode.window.showTextDocument(docToRender, { viewColumn: vscode.ViewColumn.One });
+        } catch {
+          /* keep preview focused if document tab is unavailable */
+        }
+      }
     }
   }
 
@@ -371,16 +380,19 @@ export function activate(context: vscode.ExtensionContext): void {
   // Watch for active editor changes
   const editorChangeDisposable = vscode.window.onDidChangeActiveTextEditor(
     async (editor) => {
-      if (
-        previewPanel &&
-        editor &&
-        editor.document.languageId === "markdown"
-      ) {
-        // Show loading immediately when switching files
-        const fileName = editor.document.uri.fsPath.split(/[/\\]/).pop()?.replace(/\.md$/i, '') || '';
-        previewPanel.showLoading(fileName);
-        await updatePreview(editor.document);
+      if (!editor || editor.document.languageId !== "markdown") {
+        return;
       }
+      const autoOpen = vscode.workspace.getConfiguration("obsidianPreview").get<boolean>("autoOpenPreview") !== false;
+      if (!previewPanel) {
+        if (autoOpen) {
+          await openPreviewPanel(context, false);
+        }
+        return;
+      }
+      const fileName = editor.document.uri.fsPath.split(/[/\\]/).pop()?.replace(/\.md$/i, '') || '';
+      previewPanel.showLoading(fileName);
+      await updatePreview(editor.document);
     }
   );
 
@@ -434,6 +446,13 @@ export function activate(context: vscode.ExtensionContext): void {
   autoDetectVault();
 
   logger.info("Extension activated");
+
+  // Restored window / already-active Markdown tab: open preview without requiring a tab switch
+  const autoOpenOnActivate =
+    vscode.workspace.getConfiguration("obsidianPreview").get<boolean>("autoOpenPreview") !== false;
+  if (autoOpenOnActivate && vscode.window.activeTextEditor?.document.languageId === "markdown") {
+    void openPreviewPanel(context, false);
+  }
 }
 
 async function updatePreview(document: vscode.TextDocument): Promise<void> {

--- a/vscode-extension/src/preview.ts
+++ b/vscode-extension/src/preview.ts
@@ -62,11 +62,28 @@ export class PreviewPanel {
   private vaultUri: vscode.Uri | null = null;
   private currentTitle: string | undefined;
 
-  static create(extensionUri: vscode.Uri, debugMode: boolean = false): PreviewPanel {
+  /**
+   * @param previewInSecondGroup When true (default), pin Markdown to editor group 1 and open the webview in group 2 so new files stay out of the preview group. When false, use {@link vscode.ViewColumn.Beside} (legacy behavior).
+   */
+  static async create(
+    extensionUri: vscode.Uri,
+    debugMode: boolean = false,
+    options: { previewInSecondGroup?: boolean } = {}
+  ): Promise<PreviewPanel> {
+    const previewInSecondGroup = options.previewInSecondGroup !== false;
+
     // Get all workspace folders and active editor's folder
     const workspaceFolders = vscode.workspace.workspaceFolders;
     const activeEditor = vscode.window.activeTextEditor;
-    
+
+    // Keep Markdown sources in column 1 so the preview opens in column 2
+    if (previewInSecondGroup && activeEditor?.document.languageId === "markdown") {
+      await vscode.window.showTextDocument(activeEditor.document, {
+        viewColumn: vscode.ViewColumn.One,
+        preserveFocus: true,
+      });
+    }
+
     // Collect all possible resource roots
     const resourceRoots: vscode.Uri[] = [extensionUri];
     
@@ -91,10 +108,11 @@ export class PreviewPanel {
     
     const vaultUri = workspaceFolders?.[0]?.uri || (activeEditor ? vscode.Uri.joinPath(activeEditor.document.uri, '..') : null);
     
+    const viewColumn = previewInSecondGroup ? vscode.ViewColumn.Two : vscode.ViewColumn.Beside;
     const panel = vscode.window.createWebviewPanel(
       PreviewPanel.viewType,
       debugMode ? "Obsidian Preview (Debug)" : "Obsidian Preview",
-      vscode.ViewColumn.Beside,
+      viewColumn,
       {
         enableScripts: true,
         retainContextWhenHidden: true,


### PR DESCRIPTION
- Add obsidianPreview.autoOpenPreview (default true) to open the Obsidian preview when focusing Markdown or when a Markdown tab is restored.
- Add obsidianPreview.previewInSecondEditorGroup (default true) to pin Markdown in group 1 and the webview in group 2; optional legacy Beside mode.
- After initial render, refocus the Markdown document in group 1 when using the second-group layout.
- Document optional workbench.editor.autoLockGroups for obsidianPreview.
